### PR TITLE
tag the pycket/pypy revision

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,13 @@ ENV RACKETINSTALLER racket-$RACKETV-x86_64-linux.sh
 RUN wget -q https://mirror.racket-lang.org/installers/$RACKETV/$RACKETINSTALLER
 RUN /bin/bash $RACKETINSTALLER --unix-style --dest /usr
 
+ENV PYCKET_OOPSLA_2017 3573fd1
+ENV PYPY_OOPSLA_2017 7c64684c80f4
+
 RUN git clone https://github.com/pycket/pycket
 WORKDIR pycket
-RUN git checkout -q 3573fd1
-RUN hg clone -r 7c64684c80f4 https://bitbucket.org/pypy/pypy
+RUN git checkout -q $PYCKET_OOPSLA_2017
+RUN hg clone -r $PYPY_OOPSLA_2017 https://bitbucket.org/pypy/pypy
 RUN raco pkg install -t dir pycket/pycket-lang/
 
 RUN make pycket-c


### PR DESCRIPTION
This Dockerfile checks out versions of pycket & pypy that match the code
used in "Sound Gradual Typing: Only Mostly Dead" OOPSLA 2017

(Pycket and Pypy also build on their master branches, as of now)